### PR TITLE
[TASK] removed hwinfo package

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -33,5 +33,4 @@ physical_server:
     hddtemp
     lm-sensors
     lshw
-    hwinfo
 


### PR DESCRIPTION
It has been removed by ubuntu repos.